### PR TITLE
Simplify Color enum

### DIFF
--- a/src/main/kotlin/com/andreapivetta/kolor/Color.kt
+++ b/src/main/kotlin/com/andreapivetta/kolor/Color.kt
@@ -1,100 +1,38 @@
 package com.andreapivetta.kolor
 
+import com.andreapivetta.kolor.Kolor.ESCAPE
+
 /**
- * Colors
- * @author Andrea Pivetta
+ * The amount of codes required in order to jump from a foreground code to a background code. Equal to 10. For example,
+ * the foreground code for blue is "[33m", its respective background code is "[43m"
  */
-enum class Color {
-    BLACK {
-        override fun ANSI() = "\u001B[30m"
+private const val BG_JUMP = 10
 
-        override fun ANSIBackground() = "\u001B[40m"
-    },
-    RED {
-        override fun ANSI() = "\u001B[31m"
+/**
+ * An enumeration of colors supported by most terminals. Can be applied to both foreground and background.
+ */
+enum class Color(baseCode: Int) {
+    BLACK(30),
+    RED(31),
+    GREEN(32),
+    YELLOW(33),
+    BLUE(34),
+    MAGENTA(35),
+    CYAN(36),
+    LIGHT_GRAY(37),
 
-        override fun ANSIBackground() = "\u001B[41m"
-    },
-    GREEN {
-        override fun ANSI() = "\u001B[32m"
+    DARK_GRAY(90),
+    LIGHT_RED(91),
+    LIGHT_GREEN(92),
+    LIGHT_YELLOW(93),
+    LIGHT_BLUE(94),
+    LIGHT_MAGENTA(95),
+    LIGHT_CYAN(96),
+    WHITE(97);
 
-        override fun ANSIBackground() = "\u001B[42m"
-    },
-    YELLOW {
-        override fun ANSI() = "\u001B[33m"
+    /** ANSI modifier string to apply the color to the text itself */
+    val foreground: String = "$ESCAPE[${baseCode}m"
 
-        override fun ANSIBackground() = "\u001B[43m"
-    },
-    BLUE {
-        override fun ANSI() = "\u001B[34m"
-
-        override fun ANSIBackground() = "\u001B[44m"
-    },
-    MAGENTA {
-        override fun ANSI() = "\u001B[35m"
-
-        override fun ANSIBackground() = "\u001B[45m"
-    },
-    CYAN {
-        override fun ANSI() = "\u001B[36m"
-
-        override fun ANSIBackground() = "\u001B[46m"
-    },
-    LIGHT_GRAY {
-        override fun ANSI() = "\u001B[37m"
-
-        override fun ANSIBackground() = "\u001B[47m"
-    },
-    DARK_GRAY {
-        override fun ANSI() = "\u001B[90m"
-
-        override fun ANSIBackground() = "\u001B[100m"
-    },
-    LIGHT_RED {
-        override fun ANSI() = "\u001B[91m"
-
-        override fun ANSIBackground() = "\u001B[101m"
-    },
-    LIGHT_GREEN {
-        override fun ANSI() = "\u001B[92m"
-
-        override fun ANSIBackground() = "\u001B[102m"
-    },
-    LIGHT_YELLOW {
-        override fun ANSI() = "\u001B[93m"
-
-        override fun ANSIBackground() = "\u001B[103m"
-    },
-    LIGHT_BLUE {
-        override fun ANSI() = "\u001B[94m"
-
-        override fun ANSIBackground() = "\u001B[104m"
-    },
-    LIGHT_MAGENTA {
-        override fun ANSI() = "\u001B[95m"
-
-        override fun ANSIBackground() = "\u001B[105m"
-    },
-    LIGHT_CYAN {
-        override fun ANSI() = "\u001B[96m"
-
-        override fun ANSIBackground() = "\u001B[106m"
-    },
-    WHITE {
-        override fun ANSI() = "\u001B[97m"
-
-        override fun ANSIBackground() = "\u001B[107m"
-    };
-
-    /**
-     * Get the ANSI foreground code
-     * @return The ANSI foreground code
-     */
-    abstract fun ANSI(): String
-
-    /**
-     * Get the ANSI background code
-     * @return The ANSI foreground code
-     */
-    abstract fun ANSIBackground(): String
+    /** ANSI modifier string to apply the color the text's background */
+    val background: String = "$ESCAPE[${baseCode + BG_JUMP}m"
 }

--- a/src/main/kotlin/com/andreapivetta/kolor/Kolor.kt
+++ b/src/main/kotlin/com/andreapivetta/kolor/Kolor.kt
@@ -5,7 +5,8 @@ package com.andreapivetta.kolor
  * @author Andrea Pivetta
  */
 object Kolor {
-    private const val RESET = "\u001B[0m"
+    internal const val ESCAPE = '\u001B'
+    internal const val RESET = "$ESCAPE[0m"
 
     /**
      * Create a string that will be printed with the specified color as foreground
@@ -13,7 +14,7 @@ object Kolor {
      * @param color The color to use
      * @return The colored string
      */
-    fun foreground(string: String, color: Color) = Kolor.color(string, color.ANSI())
+    fun foreground(string: String, color: Color) = Kolor.color(string, color.foreground)
 
     /**
      * Create a string that will be printed with the specified color as background
@@ -21,7 +22,7 @@ object Kolor {
      * @param color The color to use
      * @return The colored string
      */
-    fun background(string: String, color: Color) = Kolor.color(string, color.ANSIBackground())
+    fun background(string: String, color: Color) = Kolor.color(string, color.background)
 
     private fun color(string: String, ansiString: String) = "$ansiString$string$RESET"
 }

--- a/src/test/kotlin/com/andreapivetta/kolor/KolorTest.kt
+++ b/src/test/kotlin/com/andreapivetta/kolor/KolorTest.kt
@@ -5,12 +5,14 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
+import com.andreapivetta.kolor.Kolor.RESET
+
 object KolorTest : Spek({
     describe("foreground/background") {
         it("should create a string that starts with an ANSI code and ends with the reset code") {
             for (color in Color.values()) {
-                Kolor.foreground("foo", color).should.equal("${color.ANSI()}foo\u001B[0m")
-                Kolor.background("foo", color).should.equal("${color.ANSIBackground()}foo\u001B[0m")
+                Kolor.foreground("foo", color).should.equal("${color.foreground}foo$RESET")
+                Kolor.background("foo", color).should.equal("${color.background}foo$RESET")
             }
         }
     }


### PR DESCRIPTION
This PR simplifies the logic necessary to create each ANSI escape code for the foreground and background.

It also replaces the abstract functions `ANSI()` and `ANSIBackground()` with the more Kotlin-like properties `foreground` and `background`.